### PR TITLE
Fix nickname priority and extra text italitcs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -42,7 +42,7 @@ async def on_message(message):
         redirection_url = create_redirection_url(steam_link)
 
         if redirection_url:
-            author_name = message.author.nick if message.author.nick else message.author.name
+            author_name = message.author.display_name if message.author.display_name else message.author.name
             response  = f"*{author_name} has created a steam lobby link"
             response += "!*\n"
             response += f"[{steam_link}]({redirection_url})"

--- a/src/main.py
+++ b/src/main.py
@@ -64,7 +64,7 @@ async def on_message(message):
                 response += f" for {userping_match.group(0)}"
                 response += "!*\n"
                 if not extra_text.isspace():
-                    response += f"With additional text: *{extra_text}*\n"
+                    response += f"With additional text: *{extra_text.strip()}*\n"
                 response += f"[{steam_link}]({redirection_url})"
                 await sent.edit(content=response, view=ButtonView(redirection_url))
 


### PR DESCRIPTION
Just a few small changes

Discord seems to treat guild and profile nicknames differently, so I've made it prioritise the guild one since that makes more sense for the steam link to be associated with

Love the extra text change! If you put a space after the tagged user it treats that as part of the extra text which messes up the italics formatting, so I've stripped out any whitetext before/after with a quick string strip

![image](https://github.com/CarterPhan/SteamLinkerBot/assets/10883497/08e8903c-dac8-4999-a94c-5e353ecb5452)
